### PR TITLE
Docker 사용을 위한 Dockerfile / docker-compose.yml 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
-FROM openjdk:8-jdk-alpine
-ARG JAR_FILE=target/*.jar
-COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+FROM java:8
+
+VOLUME /tmp
+
+EXPOSE 10754
+
+ARG JAR_FILE=grouping-core/build/libs/grouping-core-0.0.1-SNAPSHOT.jar
+
+COPY ${JAR_FILE} grouping.jar
+
+ENTRYPOINT ["java","-jar","/grouping.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:8-jdk-alpine
+ARG JAR_FILE=target/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ VOLUME /tmp
 
 EXPOSE 10754
 
-ARG JAR_FILE=grouping-core/build/libs/grouping-core-0.0.1-SNAPSHOT.jar
+ARG JAR_FILE=grouping-api/build/libs/grouping-api-0.0.1-SNAPSHOT.jar
 
 COPY ${JAR_FILE} grouping.jar
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.8'
+
+services:
+  mysql:
+    container_name: mysql
+    image: mysql:latest
+    environment:
+      MYSQL_DATABASE: groupings
+      MYSQL_ROOT_HOST: '%'
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_USER: covengers
+      MYSQL_PASSWORD: covengers
+    ports:
+      - 3306:3306
+
+  grouping_application:
+    image: grouping
+    ports:
+      - 10754:10754
+    depends_on:
+      - mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,12 @@ services:
       MYSQL_USER: covengers
       MYSQL_PASSWORD: covengers
 
+  redis:
+    container_name: redis
+    image: redis
+    ports:
+    - 6379:6379
+
   app:
     build :
       context : .
@@ -22,3 +28,4 @@ services:
     restart: always
     depends_on:
       - mysql
+      - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,15 +6,16 @@ services:
     image: mysql:latest
     environment:
       MYSQL_DATABASE: groupings
-      MYSQL_ROOT_HOST: '%'
-      MYSQL_ROOT_PASSWORD: root
+      MYSQL_ROOT_PASSWORD: 0000
       MYSQL_USER: covengers
       MYSQL_PASSWORD: covengers
     ports:
       - 3306:3306
 
   grouping_application:
-    image: grouping
+    build :
+      context : .
+      dockerfile: Dockerfile
     ports:
       - 10754:10754
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       MYSQL_USER: covengers
       MYSQL_PASSWORD: covengers
 
-  grouping_application:
+  app:
     build :
       context : .
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,27 @@ services:
     ports:
     - 6379:6379
 
+  zookeeper:
+    container_name: zookeeper
+    image: wurstmeister/zookeeper:3.4.6
+    ports:
+      - "2181:2181"
+
+  kafka:
+    container_name: kafka
+    image: wurstmeister/kafka:2.12-2.3.0
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: 127.0.0.1
+      KAFKA_ADVERTISED_PORT: 9092
+#      KAFKA_CREATE_TOPICS: "test:1:1"
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
   app:
     build :
       context : .
@@ -29,3 +50,4 @@ services:
     depends_on:
       - mysql
       - redis
+      - kafka

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,17 @@
-version: '3.8'
+version: '3.7'
 
 services:
   mysql:
     container_name: mysql
-    image: mysql:latest
-    environment:
-      MYSQL_DATABASE: groupings
-      MYSQL_ROOT_PASSWORD: 0000
-      MYSQL_USER: covengers
-      MYSQL_PASSWORD: covengers
+    image: mysql
     ports:
       - 3306:3306
+    environment:
+      MYSQL_DATABASE: groupings
+      MYSQL_ROOT_HOST: '%'
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_USER: covengers
+      MYSQL_PASSWORD: covengers
 
   grouping_application:
     build :
@@ -18,5 +19,6 @@ services:
       dockerfile: Dockerfile
     ports:
       - 10754:10754
+    restart: always
     depends_on:
       - mysql

--- a/grouping-api/build.gradle
+++ b/grouping-api/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 //    implementation 'org.springframework.session:spring-session-core'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
-//    implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'org.springframework.kafka:spring-kafka'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'mysql:mysql-connector-java'
     annotationProcessor 'org.projectlombok:lombok'
@@ -49,7 +49,7 @@ dependencies {
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }
-//    testImplementation 'org.springframework.kafka:spring-kafka-test'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 }
 
 

--- a/grouping-api/src/main/resources/application.yml
+++ b/grouping-api/src/main/resources/application.yml
@@ -2,6 +2,7 @@ server:
 #  address: localhost # Without Docker
   address: 0.0.0.0   # With Docker
   port: 10754
+
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -11,6 +12,7 @@ spring:
 #    url: jdbc:mysql://localhost:3306/groupings?useSSL=false&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&serverTimezone=UTC    # Without Docker
     url: jdbc:mysql://mysql:3306/groupings?useSSL=false&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&serverTimezone=UTC    # With Docker
     username: covengers
+
   jpa:
     database: mysql
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
@@ -18,6 +20,7 @@ spring:
     hibernate:
       ddl-auto: create
     show-sql: true
+
   redis:
     host: 127.0.0.1
     lettuce:
@@ -26,6 +29,23 @@ spring:
         max-idle: 10
         min-idle: 2
     port: 6379
+
+  kafka:
+    bootstrap-servers: 127.0.0.1:9092
+    consumer:
+      medium-jjeaby-group-id: medium-jjeaby-group
+      company-jjeaby-group-id: company-jjeaby-group
+      auto-offset-reset: latest
+      enable-auto-commit: true
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      max-poll-records: 1000
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    template:
+      company-jjeaby-topic: company-jjeaby-topic
+      medium-jjeaby-topic: medium-jjeaby-topic
 
   servlet:
     multipart:

--- a/grouping-api/src/main/resources/application.yml
+++ b/grouping-api/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 server:
-#  address: localhost # Without Docker
-  address: 0.0.0.0   # With Docker
+  address: localhost # Without Docker
+#  address: 0.0.0.0   # With Docker
   port: 10754
 
 spring:
@@ -9,8 +9,8 @@ spring:
     initialization-mode: always
     password: covengers
     sql-script-encoding: UTF-8
-#    url: jdbc:mysql://localhost:3306/groupings?useSSL=false&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&serverTimezone=UTC    # Without Docker
-    url: jdbc:mysql://mysql:3306/groupings?useSSL=false&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&serverTimezone=UTC    # With Docker
+    url: jdbc:mysql://localhost:3306/groupings?useSSL=false&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&serverTimezone=UTC    # Without Docker
+#    url: jdbc:mysql://mysql:3306/groupings?useSSL=false&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&serverTimezone=UTC    # With Docker
     username: covengers
 
   jpa:

--- a/grouping-api/src/main/resources/application.yml
+++ b/grouping-api/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
     initialization-mode: always
     password: covengers
     sql-script-encoding: UTF-8
-    url: jdbc:mysql://mysql:3306/groupings?useSSL=false&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&serverTimezone=UTC
+    url: jdbc:mysql://localhost:3306/groupings?useSSL=false&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&serverTimezone=UTC
     username: covengers
   jpa:
     database: mysql

--- a/grouping-api/src/main/resources/application.yml
+++ b/grouping-api/src/main/resources/application.yml
@@ -1,5 +1,6 @@
 server:
-  address: localhost
+#  address: localhost # Without Docker
+  address: 0.0.0.0   # With Docker
   port: 10754
 spring:
   datasource:
@@ -7,7 +8,8 @@ spring:
     initialization-mode: always
     password: covengers
     sql-script-encoding: UTF-8
-    url: jdbc:mysql://localhost:3306/groupings?useSSL=false&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&serverTimezone=UTC
+#    url: jdbc:mysql://localhost:3306/groupings?useSSL=false&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&serverTimezone=UTC    # Without Docker
+    url: jdbc:mysql://mysql:3306/groupings?useSSL=false&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&serverTimezone=UTC    # With Docker
     username: covengers
   jpa:
     database: mysql

--- a/grouping-api/src/main/resources/application.yml
+++ b/grouping-api/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
     initialization-mode: always
     password: covengers
     sql-script-encoding: UTF-8
-    url: jdbc:mysql://localhost:3306/groupings?useSSL=false&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&serverTimezone=UTC
+    url: jdbc:mysql://mysql:3306/groupings?useSSL=false&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&serverTimezone=UTC
     username: covengers
   jpa:
     database: mysql

--- a/grouping-core/build.gradle
+++ b/grouping-core/build.gradle
@@ -27,9 +27,7 @@ bootJar {
 jar {
     enabled = true
     manifest {
-        attributes 'Title':'Grouping',
-        'Version':1.0,
-        'Main-Class':'com.covengers.grouping.GroupingApiApplication'
+        attributes 'Main-Class':'com.covengers.grouping.GroupingApiApplication'
     }
     from {
         configurations.compile.collect {it.isDirectory()? it: zipTree(it)}

--- a/grouping-core/build.gradle
+++ b/grouping-core/build.gradle
@@ -26,12 +26,6 @@ bootJar {
 
 jar {
     enabled = true
-    manifest {
-        attributes 'Main-Class':'com.covengers.grouping.GroupingApiApplication'
-    }
-    from {
-        configurations.compile.collect {it.isDirectory()? it: zipTree(it)}
-    }
 }
 
 dependencies {

--- a/grouping-core/build.gradle
+++ b/grouping-core/build.gradle
@@ -26,6 +26,14 @@ bootJar {
 
 jar {
     enabled = true
+    manifest {
+        attributes 'Title':'Grouping',
+        'Version':1.0,
+        'Main-Class':'com.covengers.grouping.GroupingApiApplication'
+    }
+    from {
+        configurations.compile.collect {it.isDirectory()? it: zipTree(it)}
+    }
 }
 
 dependencies {


### PR DESCRIPTION
issue
- Dockerfile / docker-compose.yml 기본 설정 추가

what are changed
- Dockerfile 추가
- docker-compose.yml 추가
- build.gradle에  kafka dependency 추가
- application.yml에 kafka 기본 설정 추가
- application.yml에 docker환경을 위한 코드 추가 후 주석 처리

FYI

최종적으로 "docker-compose up" 명령어로 컨테이너를 띄웠을 때 
app / kafka / zookeeper / redis / mysql 컨테이너가 잘 생성되어 동작함을 확인하였습니다.

다만, redis, kafka(+zookeeper)을 사용하는 api가 아직 없어, 실제로 도커 서버로 띄웠을 때 완전하게 통신이 이루어지는지는 테스트하지 못했습니다. -> 이 부분 정정하겠습니다. redis를 사용하는 api (recommendGroup, SignController 내부 api)들이 있는데, redis를 통한 실제 통신이 잘 작동하는지 또한 나중에 확인해보겠습니다.

추후에 해당 기술 스택을 이용하여 개발한 후에 테스트해봐야할 것 같습니다.

app(메인 컨테이너)와 mysql은 localhost:10754 접속과 postman을 통한 api 통신 테스트를 통해서 도커 서버에서도 잘 동작함을 확인했습니다.

기존의 local 서버 환경에서 docker 서버 환경으로 바꾸어 부트할 때 사용했던 방법을 공유하고자 합니다.
1. grouping-api/application.yml에서 server.address와 datasource.url을 docker에 맞게 스위치 ( 주석 처리 된 부분입니다.)
- 가상 외부 서버에서 돌아가다보니 기존의 localhost:10754가 아닌 tcp방식의 0.0.0.0/10754로 서버가 열리는데, 위 설정을 맞추어주지 않으면 docker-compose.yml 에서 설정해놓은 포트포워딩을 위한 ports 설정부분이 잘 동작하지 않음을 확인했습니다.

2. gradle -pgrouping-api build : grouping-api jar 생성

 3.docker-compose up : docker 띄우기


잘못된 부분이나 추가해야할 부분 또는 수정할 부분 리뷰 부탁드립니다! 
그리고, deeplearning4j는 도커 컴포즈에 추가하지 않는지 질문드립니다.