### PR TITLE
fixed error in Sign_In logic and optimizing

### DIFF
--- a/grouping-api/src/main/java/com/covengers/grouping/component/RequestContextHelper.java
+++ b/grouping-api/src/main/java/com/covengers/grouping/component/RequestContextHelper.java
@@ -17,7 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class RequestContextHelper {
 
-    public GroupingUserInfoVo getGroupingUserVo() {
+    public GroupingUserInfoVo getGroupingUserInfoVo() {
         return GroupingUserInfoVo.builder()
                                  .groupingUserId(
                                          Long.parseLong(getValueFromHeaders(RequestHeaders.GROUPING_USER_ID)))

--- a/grouping-api/src/main/java/com/covengers/grouping/configuration/SecurityConfiguration.java
+++ b/grouping-api/src/main/java/com/covengers/grouping/configuration/SecurityConfiguration.java
@@ -1,9 +1,12 @@
 package com.covengers.grouping.configuration;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 @EnableWebSecurity
@@ -12,6 +15,11 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.csrf().disable();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 
 }

--- a/grouping-api/src/main/java/com/covengers/grouping/controller/GroupController.java
+++ b/grouping-api/src/main/java/com/covengers/grouping/controller/GroupController.java
@@ -2,8 +2,10 @@ package com.covengers.grouping.controller;
 
 import java.io.IOException;
 
+import com.covengers.grouping.component.RequestContextHelper;
 import com.covengers.grouping.service.KeywordService;
 
+import com.covengers.grouping.vo.GroupingUserInfoVo;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -25,11 +27,14 @@ public class GroupController extends AppApiV1Controller {
     private final GroupService groupService;
     private final KeywordService keywordService;
     private final CommonResponseMaker commonResponseMaker;
+    private final RequestContextHelper requestContextHelper;
 
     @PostMapping("/group")
     public CommonResponse<GroupDto> createGroup(@RequestBody CreateGroupRequestDto requestDto) {
 
-        final GroupDto responseDto = GroupDto.of(groupService.createGroup(requestDto.toVo()));
+        final GroupingUserInfoVo groupingUserInfoVo = requestContextHelper.getGroupingUserInfoVo();
+
+        final GroupDto responseDto = GroupDto.of(groupService.createGroup(requestDto.toVo(groupingUserInfoVo.getGroupingUserId())));
 
         return commonResponseMaker.makeSucceedCommonResponse(responseDto);
     }

--- a/grouping-api/src/main/java/com/covengers/grouping/dto/CreateGroupRequestDto.java
+++ b/grouping-api/src/main/java/com/covengers/grouping/dto/CreateGroupRequestDto.java
@@ -22,22 +22,21 @@ public class CreateGroupRequestDto {
     private final Long pointX;
     private final Long pointY;
     private final String pointDescription;
-    private final Long representGroupingUserId;
     private final List<String> hashtagList;
 
-    public CreateGroupRequestVo toVo() {
+    public CreateGroupRequestVo toVo(Long representGroupingUserId) {
         return CreateGroupRequestVo.builder()
-                                   .title(title)
-                                   .isHidden(isHidden)
-                                   .minUserAge(minUserAge)
-                                   .maxUserAge(maxUserAge)
-                                   .availableGender(availableGender)
-                                   .description(description)
-                                   .pointX(pointX)
-                                   .pointY(pointY)
-                                   .pointDescription(pointDescription)
-                                   .representGroupingUserId(representGroupingUserId)
-                                   .hashtagList(hashtagList)
-                                   .build();
+                .title(title)
+                .isHidden(isHidden)
+                .minUserAge(minUserAge)
+                .maxUserAge(maxUserAge)
+                .availableGender(availableGender)
+                .description(description)
+                .pointX(pointX)
+                .pointY(pointY)
+                .pointDescription(pointDescription)
+                .representGroupingUserId(representGroupingUserId)
+                .hashtagList(hashtagList)
+                .build();
     }
 }

--- a/grouping-api/src/main/java/com/covengers/grouping/service/GroupService.java
+++ b/grouping-api/src/main/java/com/covengers/grouping/service/GroupService.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 
 import javax.transaction.Transactional;
 
+import com.covengers.grouping.component.RequestContextHelper;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -45,6 +46,7 @@ public class GroupService {
     private final GroupHashtagMappingRepository groupHashtagMappingRepository;
     private final GroupingUserRepository groupingUserRepository;
     private final UserGroupMappingRepository userGroupMappingRepository;
+    private final RequestContextHelper requestContextHelper;
 
     @Transactional
     public GroupVo createGroup(CreateGroupRequestVo requestVo) {

--- a/grouping-api/src/main/java/com/covengers/grouping/service/UserService.java
+++ b/grouping-api/src/main/java/com/covengers/grouping/service/UserService.java
@@ -2,6 +2,7 @@ package com.covengers.grouping.service;
 
 import java.util.Optional;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,6 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 public class UserService {
     private final GroupingUserRepository groupingUserRepository;
     private final PhoneNationCodeClassifier phoneNationCodeClassifier;
+    private final PasswordEncoder passwordEncoder;
 
     public CheckEmailResultVo checkEmail(String email) {
 
@@ -148,7 +150,7 @@ public class UserService {
         final GroupingUser groupingUser =
                 groupingUserOptional.orElseThrow(() -> new CommonException(ResponseCode.USER_NOT_EXISTED));
 
-        if (!groupingUser.getPassword().equals(requestVo.getPassword())) {
+        if (!passwordEncoder.matches(requestVo.getPassword(), groupingUser.getPassword())) {
             throw new CommonException(ResponseCode.INVALID_PASSWORD);
         }
 
@@ -169,7 +171,7 @@ public class UserService {
         final GroupingUser groupingUser =
                 groupingUserOptional.orElseThrow(() -> new CommonException(ResponseCode.USER_NOT_EXISTED));
 
-        if (!groupingUser.getPassword().equals(requestVo.getPassword())) {
+        if (!passwordEncoder.matches(requestVo.getPassword(), groupingUser.getPassword())) {
             throw new CommonException(ResponseCode.INVALID_PASSWORD);
         }
 

--- a/grouping-gw/src/main/java/com/covengers/grouping/adapter/api/GroupingApiRequestInterceptor.java
+++ b/grouping-gw/src/main/java/com/covengers/grouping/adapter/api/GroupingApiRequestInterceptor.java
@@ -2,6 +2,9 @@ package com.covengers.grouping.adapter.api;
 
 import java.util.Objects;
 
+import com.covengers.grouping.vo.UserPrincipal;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -19,11 +22,16 @@ public class GroupingApiRequestInterceptor implements RequestInterceptor {
     public void apply(RequestTemplate template) {
 
         final SecurityContext securityContext = SecurityContextHolder.getContext();
-        if (Objects.isNull(securityContext) || !securityContext.getAuthentication().isAuthenticated()) {
+        if (Objects.isNull(securityContext)
+                || !securityContext.getAuthentication().isAuthenticated()
+                || securityContext.getAuthentication() instanceof AnonymousAuthenticationToken) {
             return;
         }
 
+        final UserPrincipal principal = (UserPrincipal) securityContext.getAuthentication().getPrincipal();
+
         template.header(RequestHeaders.GROUPING_USER_ID,
-                        securityContext.getAuthentication().getCredentials().toString());
+                principal.getGroupingUserId().toString());
+
     }
 }

--- a/grouping-gw/src/main/java/com/covengers/grouping/adapter/api/dto/CreateGroupCompleteRequestDto.java
+++ b/grouping-gw/src/main/java/com/covengers/grouping/adapter/api/dto/CreateGroupCompleteRequestDto.java
@@ -22,7 +22,6 @@ public class CreateGroupCompleteRequestDto {
     private final Long pointX;
     private final Long pointY;
     private final String pointDescription;
-    private final Long representGroupingUserId;
     private final List<String> hashtagList;
 
     public static CreateGroupCompleteRequestDto of(CreateGroupRequestVo vo) {
@@ -36,7 +35,6 @@ public class CreateGroupCompleteRequestDto {
                 .pointX(vo.getPointX())
                 .pointY(vo.getPointY())
                 .pointDescription(vo.getPointDescription())
-                .representGroupingUserId(vo.getRepresentGroupingUserId())
                 .hashtagList(vo.getHashtagList())
                 .build();
     }

--- a/grouping-gw/src/main/java/com/covengers/grouping/configuration/JwtAuthenticationFilter.java
+++ b/grouping-gw/src/main/java/com/covengers/grouping/configuration/JwtAuthenticationFilter.java
@@ -7,10 +7,10 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.covengers.grouping.vo.UserPrincipal;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -40,11 +40,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 final Long groupingUserId = tokenProvider.getUserIdFromJwt(jwt);
 
-                final UserDetails userDetails = groupingUserRepository.loadUserById(groupingUserId);
+                final UserPrincipal userPrincipal = groupingUserRepository.loadUserById(groupingUserId);
 
                 final UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(userDetails, null,
-                                                                userDetails.getAuthorities());
+                        new UsernamePasswordAuthenticationToken(userPrincipal, null,
+                                                                userPrincipal.getAuthorities());
 
                 authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/grouping-gw/src/main/java/com/covengers/grouping/dto/CreateGroupRequestDto.java
+++ b/grouping-gw/src/main/java/com/covengers/grouping/dto/CreateGroupRequestDto.java
@@ -22,7 +22,6 @@ public class CreateGroupRequestDto {
     private final Long pointX;
     private final Long pointY;
     private final String pointDescription;
-    private final Long representGroupingUserId;
     private final List<String> hashtagList;
 
     public CreateGroupRequestVo toVo() {
@@ -36,7 +35,6 @@ public class CreateGroupRequestDto {
                 .pointX(pointX)
                 .pointY(pointY)
                 .pointDescription(pointDescription)
-                .representGroupingUserId(representGroupingUserId)
                 .hashtagList(hashtagList)
                 .build();
     }

--- a/grouping-gw/src/main/java/com/covengers/grouping/service/GroupingUserRepositoryDecorator.java
+++ b/grouping-gw/src/main/java/com/covengers/grouping/service/GroupingUserRepositoryDecorator.java
@@ -54,7 +54,7 @@ public class GroupingUserRepositoryDecorator implements UserDetailsService {
     }
 
     @Transactional
-    public UserDetails loadUserById(Long id) {
+    public UserPrincipal loadUserById(Long id) {
         final GroupingUser user =
                 groupingUserRepository.findTopById(id)
                                       .orElseThrow(() -> new CommonException(ResponseCode.USER_NOT_EXISTED));

--- a/grouping-gw/src/main/java/com/covengers/grouping/vo/CreateGroupRequestVo.java
+++ b/grouping-gw/src/main/java/com/covengers/grouping/vo/CreateGroupRequestVo.java
@@ -20,6 +20,5 @@ public class CreateGroupRequestVo {
     private final Long pointX;
     private final Long pointY;
     private final String pointDescription;
-    private final Long representGroupingUserId;
     private final List<String> hashtagList;
 }


### PR DESCRIPTION
#### What are changed

1. Spring Security의 PasswordEncoder를 채택하면서 발생한 sign in 로그인 에러 수정
회원가입시 랜덤하게 암호화되어 db에 저장된 password와 로그인 시 전달받은 원형의 password를 비교하기 위해서 passwordEncoder의 match 메소드를 사용하여 정상 동작함을 확인했습니다.

2. requestInterceptor가 SignIn 메소드에서 작동하지 않도록 조건문 추가
SignIn 메소드 시에는 Authenticated=true 이지만 UserPrincipal은 AnonymousUser이며, UserDetail 정보를 담고 있지 않습니다. 이로 인해 인터셉터가 Header를 넘겨줄 때 발생한 오류를 수정하였습니다.

3. template.header(RequestHeaders.GROUPING_USER_ID,
                principal.getGroupingUserId().toString());   -> grouping_user_id를 전달하는 코드를 수정하였습니다.

4. 최종적으로 requestContextHelper가 작동함을 확인했고, 기존 createGroup에서 groupingUserId를 인자로 전달받던 방식에서 contextHelper을 통해서 전달받는 방식으로 수정하였습니다.

리뷰 부탁드립니다.

이와 같은 방식이 맞다면 추가적으로 groupingUserId를 requestbody나 requestparam으로 넘겨주는 api들을 createGroup메소드와 같이 수정할 예정입니다.