### PR TITLE
ChatRoom 상속관계 매핑

### DIFF
--- a/grouping-core/src/main/java/com/covengers/grouping/domain/ChatRoom.java
+++ b/grouping-core/src/main/java/com/covengers/grouping/domain/ChatRoom.java
@@ -1,0 +1,35 @@
+package com.covengers.grouping.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "room_type")
+@Table(name = "chat_room")
+public abstract class ChatRoom extends AbstractAuditingEntity {
+
+    private static final long serialVersionUID = 3479252314649405287L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "chat_room_id")
+    protected Long id;
+
+    @Column(name = "title")
+    protected String title;
+
+    @Column(name = "topic_id")
+    protected String topicId;
+
+    @OneToMany(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id")
+    protected List<GroupingUser> userList = new ArrayList<>();
+
+}

--- a/grouping-core/src/main/java/com/covengers/grouping/domain/GroupChatRoom.java
+++ b/grouping-core/src/main/java/com/covengers/grouping/domain/GroupChatRoom.java
@@ -17,24 +17,10 @@ import java.util.UUID;
 @Entity
 @EqualsAndHashCode(of = "id", callSuper = false)
 @Table(name = "group_chat_room")
-public class GroupChatRoom extends AbstractAuditingEntity {
+@DiscriminatorValue("group")
+public class GroupChatRoom extends ChatRoom {
 
     private static final long serialVersionUID = 1489983754860461043L;
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "group_chat_room_id")
-    private Long id;
-
-    @Column(name = "title")
-    private String title;
-
-    @Column(name = "topic_id")
-    private String topicId;
-
-    @OneToMany(fetch = FetchType.LAZY)
-    @JoinColumn(name = "group_chat_room_id")
-    private List<GroupingUser> userList = new ArrayList<>();
 
     public GroupChatRoom(String title) {
         this.title = title;


### PR DESCRIPTION
### issue & What are changed
ChatRoom -> GroupChatRoom 상속관계 매핑

### FYI

조인 전략 vs 싱글 테이블 전략 중, 정규화보단 실제 성능을 고려한 싱글 테이블 전략을 선택하였습니다.

![image](https://user-images.githubusercontent.com/71204049/108302107-a46dad00-71e6-11eb-86f2-ff433b5bfdfd.png)

DB 조회 시 이와 같습니다. 아직 다형성된 개별 필드값이 없어 group_chat_room은 empty값으로 조회됩니다.



이렇게 하는 것이 적절한지 리뷰 부탁드립니다.