### PR TITLE
유저채팅방 설계

### DIFF
--- a/grouping-api/src/main/java/com/covengers/grouping/dto/UserChatRoomDto.java
+++ b/grouping-api/src/main/java/com/covengers/grouping/dto/UserChatRoomDto.java
@@ -1,0 +1,23 @@
+package com.covengers.grouping.dto;
+
+import com.covengers.grouping.vo.UserChatRoomVo;
+import lombok.*;
+
+@ToString
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserChatRoomDto {
+
+    private Long id;
+
+    private String topicId;
+
+    public static UserChatRoomDto of(UserChatRoomVo vo) {
+        return builder()
+                .id(vo.getId())
+                .topicId(vo.getTopicId())
+                .build();
+    }
+}

--- a/grouping-chat/src/main/java/com/covengers/grouping/controller/ChatController.java
+++ b/grouping-chat/src/main/java/com/covengers/grouping/controller/ChatController.java
@@ -2,9 +2,7 @@ package com.covengers.grouping.controller;
 
 import com.covengers.grouping.component.CommonResponseMaker;
 import com.covengers.grouping.domain.ChatMessage;
-import com.covengers.grouping.dto.CreateGroupChatRoomRequestDto;
-import com.covengers.grouping.dto.GroupChatRoomDto;
-import com.covengers.grouping.dto.CommonResponse;
+import com.covengers.grouping.dto.*;
 import com.covengers.grouping.service.ChatService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,12 +17,22 @@ public class ChatController extends AppChatV1Controller {
     private final ChatService chatService;
     private final CommonResponseMaker commonResponseMaker;
 
-    @PostMapping("/chat/room-group")
+    @PostMapping("/chat/group-room")
     public CommonResponse<GroupChatRoomDto> createGroupChatRoom(
             @RequestBody CreateGroupChatRoomRequestDto requestDto) {
 
         final GroupChatRoomDto responseDto = GroupChatRoomDto.of(
                 chatService.createGroupChatRoom(requestDto.toVo()));
+
+        return commonResponseMaker.makeSucceedCommonResponse(responseDto);
+    }
+
+    @PostMapping("/chat/user-room")
+    public CommonResponse<UserChatRoomDto> createUserChatRoom(
+                @RequestBody CreateUserChatRoomRequestDto requestDto) {
+
+        final UserChatRoomDto responseDto = UserChatRoomDto.of(
+                chatService.createUserChatRoom(requestDto.toVo()));
 
         return commonResponseMaker.makeSucceedCommonResponse(responseDto);
     }

--- a/grouping-chat/src/main/java/com/covengers/grouping/dto/CreateUserChatRoomRequestDto.java
+++ b/grouping-chat/src/main/java/com/covengers/grouping/dto/CreateUserChatRoomRequestDto.java
@@ -1,0 +1,22 @@
+package com.covengers.grouping.dto;
+
+import com.covengers.grouping.vo.CreateUserChatRoomRequestVo;
+import lombok.*;
+
+import java.util.List;
+
+@ToString
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CreateUserChatRoomRequestDto {
+
+    private List<Long> groupingUserIdList;
+
+    public CreateUserChatRoomRequestVo toVo() {
+        return CreateUserChatRoomRequestVo.builder()
+                .groupingUserIdList(groupingUserIdList)
+                .build();
+    }
+}

--- a/grouping-chat/src/main/java/com/covengers/grouping/dto/UserChatRoomDto.java
+++ b/grouping-chat/src/main/java/com/covengers/grouping/dto/UserChatRoomDto.java
@@ -1,0 +1,23 @@
+package com.covengers.grouping.dto;
+
+import com.covengers.grouping.vo.UserChatRoomVo;
+import lombok.*;
+
+@ToString
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UserChatRoomDto {
+
+    private Long id;
+
+    private String topicId;
+
+    public static UserChatRoomDto of(UserChatRoomVo vo) {
+        return builder()
+                .id(vo.getId())
+                .topicId(vo.getTopicId())
+                .build();
+    }
+}

--- a/grouping-chat/src/main/java/com/covengers/grouping/service/ChatService.java
+++ b/grouping-chat/src/main/java/com/covengers/grouping/service/ChatService.java
@@ -2,13 +2,14 @@ package com.covengers.grouping.service;
 
 import com.covengers.grouping.component.GroupRepositoryDecorator;
 import com.covengers.grouping.component.GroupingUserRepositoryDecorator;
-import com.covengers.grouping.domain.ChatMessage;
-import com.covengers.grouping.domain.Group;
-import com.covengers.grouping.domain.GroupChatRoom;
-import com.covengers.grouping.domain.GroupingUser;
+import com.covengers.grouping.domain.*;
+import com.covengers.grouping.dto.CreateUserChatRoomRequestDto;
 import com.covengers.grouping.repository.GroupChatRoomRepository;
+import com.covengers.grouping.repository.UserChatRoomRepository;
 import com.covengers.grouping.vo.CreateGroupChatRoomRequestVo;
+import com.covengers.grouping.vo.CreateUserChatRoomRequestVo;
 import com.covengers.grouping.vo.GroupChatRoomVo;
+import com.covengers.grouping.vo.UserChatRoomVo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
@@ -23,6 +24,7 @@ import java.util.List;
 public class ChatService {
 
     private final GroupChatRoomRepository groupChatRoomRepository;
+    private final UserChatRoomRepository userChatRoomRepository;
     private final GroupRepositoryDecorator groupRepository;
     private final GroupingUserRepositoryDecorator groupingUserRepository;
     private final SimpMessageSendingOperations messagingTemplate;
@@ -46,6 +48,23 @@ public class ChatService {
         }
 
         return groupChatRoom.toVo();
+    }
+
+    @Transactional
+    public UserChatRoomVo createUserChatRoom(CreateUserChatRoomRequestVo requestVo) {
+
+        final UserChatRoom userChatRoom = new UserChatRoom();
+
+        userChatRoomRepository.save(userChatRoom);
+
+        final List<Long> groupingUserIdList = requestVo.getGroupingUserIdList();
+
+        for (Long id : groupingUserIdList) {
+            final GroupingUser groupingUser = groupingUserRepository.findTopById(id);
+            userChatRoom.getUserList().add(groupingUser);
+        }
+
+        return userChatRoom.toVo();
     }
 
     /**

--- a/grouping-core/src/main/java/com/covengers/grouping/domain/ChatRoom.java
+++ b/grouping-core/src/main/java/com/covengers/grouping/domain/ChatRoom.java
@@ -22,9 +22,6 @@ public abstract class ChatRoom extends AbstractAuditingEntity {
     @Column(name = "chat_room_id")
     protected Long id;
 
-    @Column(name = "title")
-    protected String title;
-
     @Column(name = "topic_id")
     protected String topicId;
 

--- a/grouping-core/src/main/java/com/covengers/grouping/domain/GroupChatRoom.java
+++ b/grouping-core/src/main/java/com/covengers/grouping/domain/GroupChatRoom.java
@@ -22,6 +22,9 @@ public class GroupChatRoom extends ChatRoom {
 
     private static final long serialVersionUID = 1489983754860461043L;
 
+    @Column(name = "title")
+    private String title;
+
     public GroupChatRoom(String title) {
         this.title = title;
         this.topicId = UUID.randomUUID().toString();

--- a/grouping-core/src/main/java/com/covengers/grouping/domain/UserChatRoom.java
+++ b/grouping-core/src/main/java/com/covengers/grouping/domain/UserChatRoom.java
@@ -1,0 +1,36 @@
+package com.covengers.grouping.domain;
+
+import com.covengers.grouping.vo.GroupChatRoomVo;
+import com.covengers.grouping.vo.UserChatRoomVo;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Entity
+@EqualsAndHashCode(of = "id", callSuper = false)
+@Table(name = "user_chat_room")
+@DiscriminatorValue("user")
+public class UserChatRoom extends ChatRoom {
+
+    private static final long serialVersionUID = 2038452733314775937L;
+
+    public UserChatRoom() {
+        this.topicId = UUID.randomUUID().toString();
+    }
+
+    public UserChatRoomVo toVo() {
+        return UserChatRoomVo.builder()
+                .id(id)
+                .topicId(topicId)
+                .build();
+    }
+
+}

--- a/grouping-core/src/main/java/com/covengers/grouping/repository/UserChatRoomRepository.java
+++ b/grouping-core/src/main/java/com/covengers/grouping/repository/UserChatRoomRepository.java
@@ -1,0 +1,7 @@
+package com.covengers.grouping.repository;
+
+import com.covengers.grouping.domain.UserChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserChatRoomRepository extends JpaRepository<UserChatRoom, Long> {
+}

--- a/grouping-core/src/main/java/com/covengers/grouping/vo/CreateUserChatRoomRequestVo.java
+++ b/grouping-core/src/main/java/com/covengers/grouping/vo/CreateUserChatRoomRequestVo.java
@@ -1,0 +1,15 @@
+package com.covengers.grouping.vo;
+
+import lombok.*;
+
+import java.util.List;
+
+@ToString
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CreateUserChatRoomRequestVo {
+
+    private List<Long> groupingUserIdList;
+}

--- a/grouping-core/src/main/java/com/covengers/grouping/vo/UserChatRoomVo.java
+++ b/grouping-core/src/main/java/com/covengers/grouping/vo/UserChatRoomVo.java
@@ -1,0 +1,16 @@
+package com.covengers.grouping.vo;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+public class UserChatRoomVo {
+
+    private final Long id;
+
+    private final String topicId;
+
+}


### PR DESCRIPTION
### issue & what are changed
유저채팅방 설계

### FYI
1:1 채팅으로만 한정된 유저채팅방에서 현재 title(채팅방이름)이 필요하지 않을 것 같아 GroupChatRoom 의 단독 필드값으로 뺐습니다.
이와 같은 설계가 적절한지 리뷰 부탁드립니다.

또한, 이대로 설계된다면 유저로부터 유저 채팅방 목록을 가져올 때는 UserChatRoomRepository로부터 groupingUser.userId를 조회하여 매칭되는 채팅방을 가져오는 방식으로 구현하는 것인지 질문드립니다.