### PR TITLE
adopt eureka and centralized swagger2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 
 plugins {
-    id 'org.springframework.boot' version '2.3.8.RELEASE'
+    id 'org.springframework.boot' version '2.3.9.RELEASE'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
 }

--- a/grouping-api/build.gradle
+++ b/grouping-api/build.gradle
@@ -20,6 +20,10 @@ configurations {
     }
 }
 
+ext {
+    set('springCloudVersion', "Hoxton.SR10")
+}
+
 dependencies {
     implementation project(":grouping-core")
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -32,11 +36,14 @@ dependencies {
     compile group: 'it.ozimov', name: 'embedded-redis', version: '0.7.2'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
 //    implementation 'org.springframework.kafka:spring-kafka'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'mysql:mysql-connector-java'
     annotationProcessor 'org.projectlombok:lombok'
-    implementation 'io.springfox:springfox-swagger2:2.9.2'
-    implementation 'io.springfox:springfox-swagger-ui:2.9.2'
+
+    implementation 'io.springfox:springfox-boot-starter:3.0.0'
+    implementation 'io.springfox:springfox-swagger2:3.0.0'
+    implementation 'io.springfox:springfox-swagger-ui:3.0.0'
 
     compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-zipkin', version: '2.2.3.RELEASE'
     compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-sleuth', version: '2.2.3.RELEASE'
@@ -55,6 +62,12 @@ dependencies {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }
 //    testImplementation 'org.springframework.kafka:spring-kafka-test'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 

--- a/grouping-api/src/main/java/com/covengers/grouping/configuration/SwaggerConfiguration.java
+++ b/grouping-api/src/main/java/com/covengers/grouping/configuration/SwaggerConfiguration.java
@@ -1,0 +1,22 @@
+package com.covengers.grouping.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@Configuration
+public class SwaggerConfiguration {
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.covengers.grouping.controller"))
+                .paths(PathSelectors.any())
+                .build();
+    }
+}

--- a/grouping-api/src/main/resources/application.yml
+++ b/grouping-api/src/main/resources/application.yml
@@ -1,14 +1,6 @@
 spring:
   application:
-    name: api
-
-  profiles:
-    active: local
-
----
-
-spring:
-  profiles: local
+    name: grouping-api
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -61,8 +53,10 @@ spring:
   #      max-file-size: 100MB
   #      max-request-size: 100MB
 
-server:
-  address: localhost
-  port: 10754
+eureka:
+  client:
+    serviceUrl:
+      defaultZone: http://localhost:10752/eureka
 
----
+server:
+  port: 10754

--- a/grouping-batch/src/main/resources/application.yml
+++ b/grouping-batch/src/main/resources/application.yml
@@ -2,11 +2,6 @@ spring:
   profiles:
     active: local
 
----
-
-spring:
-  profiles: local
-
   batch:
     initialize-schema: always
   datasource:
@@ -28,31 +23,3 @@ spring:
 server:
   address: localhost
   port: 10755
-
----
-
-spring:
-  profiles: dev
-
-  batch:
-    initialize-schema: always
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://0.0.0.0:3306/groupings?useSSL=false&characterEncoding=UTF-8&allowPublicKeyRetrieval=true&serverTimezone=UTC
-    username: covengers
-    password: Covengers2020@
-    initialization-mode: always
-    sql-script-encoding: UTF-8
-
-  jpa:
-    database: mysql
-    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
-    hibernate:
-      ddl-auto: none
-    generate-ddl: true
-    show-sql: true
-
-server:
-  address: 0.0.0.0
-  port: 10755
-

--- a/grouping-chat/build.gradle
+++ b/grouping-chat/build.gradle
@@ -20,14 +20,23 @@ configurations {
     }
 }
 
+ext {
+    set('springCloudVersion', "Hoxton.SR10")
+}
+
 dependencies {
     implementation project(":grouping-core")
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-zipkin', version: '2.2.3.RELEASE'
     compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-sleuth', version: '2.2.3.RELEASE'
+
+    implementation 'io.springfox:springfox-boot-starter:3.0.0'
+    implementation 'io.springfox:springfox-swagger2:3.0.0'
+    implementation 'io.springfox:springfox-swagger-ui:3.0.0'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'mysql:mysql-connector-java'
@@ -38,6 +47,12 @@ dependencies {
 
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+    }
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
     }
 }
 

--- a/grouping-chat/src/main/java/com/covengers/grouping/GroupingChatApplication.java
+++ b/grouping-chat/src/main/java/com/covengers/grouping/GroupingChatApplication.java
@@ -2,8 +2,10 @@ package com.covengers.grouping;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
 
 @SpringBootApplication
+@EnableEurekaClient
 public class GroupingChatApplication {
 
     public static void main(String[] args) {

--- a/grouping-chat/src/main/java/com/covengers/grouping/configuration/SwaggerConfiguration.java
+++ b/grouping-chat/src/main/java/com/covengers/grouping/configuration/SwaggerConfiguration.java
@@ -1,0 +1,22 @@
+package com.covengers.grouping.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@Configuration
+public class SwaggerConfiguration {
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.covengers.grouping.controller"))
+                .paths(PathSelectors.any())
+                .build();
+    }
+}

--- a/grouping-chat/src/main/resources/application.yml
+++ b/grouping-chat/src/main/resources/application.yml
@@ -1,14 +1,6 @@
 spring:
   application:
-    name: chat
-
-  profiles:
-    active: local
-
----
-
-spring:
-  profiles: local
+    name: grouping-chat
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -61,8 +53,10 @@ spring:
   #      max-file-size: 100MB
   #      max-request-size: 100MB
 
-server:
-  address: localhost
-  port: 10756
+eureka:
+  client:
+    serviceUrl:
+      defaultZone: http://localhost:10752/eureka
 
----
+server:
+  port: 10756

--- a/grouping-discovery/build.gradle
+++ b/grouping-discovery/build.gradle
@@ -1,0 +1,41 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot'
+    id 'io.spring.dependency-management'
+}
+
+group 'com.covengers.grouping'
+version '0.0.1-SNAPSHOT'
+
+sourceCompatibility = 11
+
+repositories {
+    mavenCentral()
+}
+
+ext {
+    set('springCloudVersion', "Hoxton.SR10")
+}
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
+dependencies {
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-server'
+
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/grouping-discovery/src/main/java/com/covengers/grouping/GroupingDiscoveryApplication.java
+++ b/grouping-discovery/src/main/java/com/covengers/grouping/GroupingDiscoveryApplication.java
@@ -2,14 +2,13 @@ package com.covengers.grouping;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
+import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
 
 @SpringBootApplication
-@EnableEurekaClient
-public class GroupingApiApplication {
+@EnableEurekaServer
+public class GroupingDiscoveryApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(GroupingApiApplication.class, args);
+        SpringApplication.run(GroupingDiscoveryApplication.class, args);
     }
-
 }

--- a/grouping-discovery/src/main/resources/application.yml
+++ b/grouping-discovery/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  application:
+    name: grouping-discovery
+
+eureka:
+  client:
+    registerWithEureka: false
+    fetchRegistry: false
+    service-url:
+      defaultZone: http://localhost:10752/eureka
+
+server:
+  port: 10752

--- a/grouping-gw/build.gradle
+++ b/grouping-gw/build.gradle
@@ -11,7 +11,7 @@ version '0.0.1-SNAPSHOT'
 sourceCompatibility = 11
 
 ext {
-    set('springCloudVersion', "Hoxton.SR9")
+    set('springCloudVersion', "Hoxton.SR10")
 }
 
 dependencies {
@@ -20,11 +20,16 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
-//    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 //    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 //    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-hystrix'
     compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-zipkin', version: '2.2.3.RELEASE'
     compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-sleuth', version: '2.2.3.RELEASE'
+
+    implementation 'io.springfox:springfox-boot-starter:3.0.0'
+    implementation 'io.springfox:springfox-swagger2:3.0.0'
+    implementation 'io.springfox:springfox-swagger-ui:3.0.0'
+
     implementation "com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.6.3"
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/grouping-gw/src/main/java/com/covengers/grouping/GroupingGwApplication.java
+++ b/grouping-gw/src/main/java/com/covengers/grouping/GroupingGwApplication.java
@@ -2,8 +2,10 @@ package com.covengers.grouping;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
 
 @SpringBootApplication
+@EnableEurekaClient
 public class GroupingGwApplication {
 
     public static void main(String[] args) {

--- a/grouping-gw/src/main/java/com/covengers/grouping/configuration/DocumentConfiguration.java
+++ b/grouping-gw/src/main/java/com/covengers/grouping/configuration/DocumentConfiguration.java
@@ -1,0 +1,32 @@
+package com.covengers.grouping.configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import springfox.documentation.swagger.web.SwaggerResource;
+import springfox.documentation.swagger.web.SwaggerResourcesProvider;
+
+@Configuration
+@Primary
+public class DocumentConfiguration implements SwaggerResourcesProvider {
+
+    @Override
+    public List<SwaggerResource> get() {
+        List<SwaggerResource> resources = new ArrayList<>();
+        resources.add(swaggerResource("grouping-api", "/v2/api-docs/api", "2.0"));
+        resources.add(swaggerResource("grouping-chat", "/v2/api-docs/chat", "2.0"));
+        resources.add(swaggerResource("grouping-gateway", "/v2/api-docs", "2.0"));
+        return resources;
+    }
+
+    private SwaggerResource swaggerResource(String name, String location, String version) {
+        SwaggerResource swaggerResource = new SwaggerResource();
+        swaggerResource.setName(name);
+        swaggerResource.setLocation(location);
+        swaggerResource.setSwaggerVersion(version);
+        return swaggerResource;
+    }
+
+}

--- a/grouping-gw/src/main/java/com/covengers/grouping/configuration/RouteConfiguration.java
+++ b/grouping-gw/src/main/java/com/covengers/grouping/configuration/RouteConfiguration.java
@@ -9,38 +9,32 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class RouteConfiguration {
 
-    @Value("${grouping.version}")
-    public String groupingVersion;
-
-    @Value("${grouping.url.api}")
-    public String groupingUrlApi;
-
-    @Value("${grouping.url.chat}")
-    public String groupingUrlChat;
-
     @Bean
     public RouteLocator gatewayRoutes(RouteLocatorBuilder builder) {
 
         return builder.routes()
-                .route(r -> r.path("/" + groupingVersion + "/group/**")
-                        .uri(groupingUrlApi)
-                        .id("grouping-api:group"))
-                .route(r -> r.path("/" + groupingVersion + "/keywords/**")
-                        .uri(groupingUrlApi)
-                        .id("grouping-api:keyword"))
-                .route(r -> r.path("/" + groupingVersion + "/sign/**")
-                        .uri(groupingUrlApi)
-                        .id("grouping-api:sign"))
-                .route(r -> r.path("/" + groupingVersion + "/users/**")
-                        .uri(groupingUrlApi)
-                        .id("grouping-api:user"))
-                .route(r -> r.path("/" + groupingVersion + "/chat/**")
-                        .uri(groupingUrlChat)
-                        .id("grouping-chat:chat"))
-                .route(r -> r.path("/websocket/**")
-                        .filters(f -> f.rewritePath("/websocket/(?.*)", "/${remains}"))
-                        .uri(groupingUrlChat)
-                        .id("grouping-chat:ws"))
+                .route(r -> r.path("/v2/api-docs/api")
+                        .filters(f -> f.rewritePath("/v2/api-docs/api", "/v2/api-docs"))
+                        .uri("lb://grouping-api")
+                        .id("grouping-api:docs"))
+                .route(r -> r.path(
+                        "/v1/group/**",
+                        "/v1/keywords/**",
+                        "/v1/sign/**",
+                        "/v1/users/**")
+                        .uri("lb://grouping-api")
+                        .id("grouping-api:api"))
+                .route(r -> r.path("/v2/api-docs/chat")
+                        .filters(f -> f.rewritePath("/v2/api-docs/chat", "/v2/api-docs"))
+                        .uri("lb://grouping-chat")
+                        .id("grouping-chat:docs"))
+                .route(r -> r.path("/v1/chat/**")
+                        .uri("lb://grouping-chat")
+                        .id("grouping-chat:api"))
+                .route(r -> r.path("/websocket/chat")
+                        .filters(f -> f.rewritePath("/websocket/chat", "/chat"))
+                        .uri("lb://grouping-chat")
+                        .id("grouping-chat:ws-connect"))
                 .build();
     }
 }

--- a/grouping-gw/src/main/java/com/covengers/grouping/configuration/SecurityConfiguration.java
+++ b/grouping-gw/src/main/java/com/covengers/grouping/configuration/SecurityConfiguration.java
@@ -34,6 +34,12 @@ public class SecurityConfiguration {
             "/v1/sign/login/phone-number",
     };
 
+    private static final String[] EXCLUDE_SWAGGER_REQUEST_PATH = {
+            "/v2/api-docs/**", "/swagger-resources/configuration/ui",
+            "/swagger-resources","/swagger-resources/configuration/security",
+            "/swagger-ui/","/webjars/**"
+    };
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -58,6 +64,8 @@ public class SecurityConfiguration {
                 .pathMatchers(EXCLUDE_POST_REQUEST_PATH)
                 .permitAll()
                 .pathMatchers(HttpMethod.GET, EXCLUDE_GET_REQUEST_PATH)
+                .permitAll()
+                .pathMatchers(EXCLUDE_SWAGGER_REQUEST_PATH)
                 .permitAll()
                 .anyExchange()
                 .authenticated()

--- a/grouping-gw/src/main/java/com/covengers/grouping/configuration/SwaggerConfiguration.java
+++ b/grouping-gw/src/main/java/com/covengers/grouping/configuration/SwaggerConfiguration.java
@@ -1,0 +1,22 @@
+package com.covengers.grouping.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+
+@Configuration
+public class SwaggerConfiguration {
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.covengers.grouping.controller"))
+                .paths(PathSelectors.any())
+                .build();
+    }
+}

--- a/grouping-gw/src/main/resources/application.yml
+++ b/grouping-gw/src/main/resources/application.yml
@@ -1,24 +1,6 @@
 spring:
   application:
-    name: gateway
-
-  profiles:
-    active: local
-
-app:
-  jwtSecret: groupingGauza!
-  jwtExpirationInMilliSecond: 86400000
-
-grouping:
-  url:
-    api: http://127.0.0.1:10754/
-    chat: http://127.0.0.1:10756/
-  version: v1
-
----
-
-spring:
-  profiles: local
+    name: grouping-gateway
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -36,6 +18,11 @@ spring:
       ddl-auto: create
 #    show-sql: true
 
+eureka:
+  client:
+    serviceUrl:
+      defaultZone: http://localhost:10752/eureka
+
   sleuth:
     sampler:
       probability: 1.0
@@ -44,7 +31,8 @@ spring:
     base-url: http://localhost:9411/
 
 server:
-  address: localhost
   port: 10753
 
----
+app:
+  jwtSecret: groupingGauza!
+  jwtExpirationInMilliSecond: 86400000

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,4 +4,5 @@ include 'grouping-core'
 include 'grouping-batch'
 include 'grouping-gw'
 include 'grouping-chat'
+include 'grouping-discovery'
 


### PR DESCRIPTION
### issue & What are changed

1. 서비스 디스커버리 및 로드 밸런싱을 위해 eureka 도입
2. Api Spec Documentation을 위한 중앙화된 swagger2 추가
3. application.yml 프로필 제거 (제가 전에 추가했었는데 현재 불필요하고 오히려 가독성이 떨어져 제거하였습니다.)

### FYI
![image](https://user-images.githubusercontent.com/71204049/109796744-e291b480-7c5b-11eb-9e2c-3c9086e35abe.png)

유레카 구동된 모습입니다. 또한, 서버에 올린 instance가 서비스당 1개씩이긴 하지만 로드 밸런싱 로직이 정상 작동함을 확인했습니다.

![image](https://user-images.githubusercontent.com/71204049/109797258-92672200-7c5c-11eb-9265-a549c519ce92.png)

이제 http://localhost:10753/swagger-ui/ 접속 시 위와 같이 모든 모듈의 api 스펙을 한번에 볼 수 있습니다.

리뷰 부탁드립니다.